### PR TITLE
Server wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,7 @@ dependencies = [
  "clap",
  "factorio-api",
  "futures",
+ "nix",
  "reqwest",
  "ron",
  "serde",
@@ -535,6 +536,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +559,20 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+ "static_assertions",
 ]
 
 [[package]]
@@ -874,6 +898,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,3 +16,4 @@ tracing = { workspace = true }
 tracing-subscriber = "0.3.16"
 ron = "0.8.0"
 futures = "0.3.28"
+nix = "0.26.2"

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -15,6 +15,7 @@ pub(crate) struct Args {
 pub(crate) enum Commands {
     Auth(Auth),
     Download(Download),
+    Server(Server),
 }
 
 #[derive(clap::Args, Debug)]
@@ -55,4 +56,32 @@ pub(crate) struct ModList {
     /// The path to the directory to download the mods to
     #[clap(long, short, default_value = ".")]
     pub directory: PathBuf,
+}
+
+#[derive(clap::Args, Debug)]
+pub(crate) struct Server {
+    #[clap(subcommand)]
+    pub command: ServerCommands,
+}
+
+#[derive(clap::Subcommand, Debug)]
+pub(crate) enum ServerCommands {
+    /// Starts the game server
+    Start(Start),
+}
+
+#[derive(clap::Args, Debug)]
+pub(crate) struct Start {
+    /// The executable to run
+    #[clap(long, short = 'e', default_value = "factorio")]
+    pub executable: String,
+    /// The path to the directory that the mods will be downloaded to
+    #[clap(long, short = 'd')]
+    pub mod_directory: PathBuf,
+    /// The path to the mod list file
+    #[clap(long, short = 'm')]
+    pub mod_list: Option<PathBuf>,
+    /// Pass-through arguments to the server
+    #[arg()]
+    pub args: Vec<String>,
 }


### PR DESCRIPTION
Instead of running the headless server directly, we now have support for running it inside of a rust process. This paves the way for adding a REST API to coexist with the game server. The ultimate goal is for the REST API to provide a health-check by communicating with the server over RPC. This is the first change in order to accomplish that.